### PR TITLE
Mac instructions might need PKG_CONFIG_PATH set

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ This project came out of the [Gopher Gala](http://gophergala.com/) 2016.  It is 
   ```
   go get golang.org/x/tools/cmd/goimports
   go get github.com/gophergala2016/gophernotes
+  
+  If you get the error:
+  
+  # pkg-config --cflags libzmq libzmq libzmq libzmq
+  Package libzmq was not found in the pkg-config search path.
+  Perhaps you should add the directory containing `libzmq.pc'
+  to the PKG_CONFIG_PATH environment variable
+  No package 'libzmq' found
+  
+  then:
+  
+  export PKG_CONFIG_PATH=/usr/local/Cellar/zeromq22/lib/pkgconfig/
+
   ```
 
 - Copy the kernel config:


### PR DESCRIPTION
If installing libzmq via homebrew doesn't set PKG_CONFIG_PATH the gophernotes install fails. Explicitly exporting PKG_CONFIG_PATH and re-running the gophernotes install fixes this.